### PR TITLE
feat: preauthorization support

### DIFF
--- a/src/stackcoin/client.py
+++ b/src/stackcoin/client.py
@@ -136,11 +136,14 @@ class Client:
         *,
         label: str | None = None,
         idempotency_key: str | None = None,
+        use_preauth: bool = False,
     ) -> CreateRequestResponse:
         """Create a STK request to another user."""
         body: dict[str, Any] = {"amount": amount}
         if label is not None:
             body["label"] = label
+        if use_preauth:
+            body["use_preauth"] = True
         headers: dict[str, str] = {}
         if idempotency_key is not None:
             headers["Idempotency-Key"] = idempotency_key
@@ -151,6 +154,29 @@ class Client:
         )
         self._raise_for_error(resp)
         return CreateRequestResponse.model_validate(resp.json())
+
+    async def create_preauth(
+        self,
+        user_id: int,
+        max_amount: int,
+        window_hours: int,
+    ) -> dict:
+        """Request a preauthorization from a user."""
+        resp = await self._http.post(
+            f"/api/user/{user_id}/preauth",
+            json={"max_amount": max_amount, "window_hours": window_hours},
+        )
+        self._raise_for_error(resp)
+        return resp.json()
+
+    async def get_preauths(self, *, user_id: int | None = None) -> list[dict]:
+        """List preauths for this bot, optionally filtered by user_id."""
+        params: dict[str, Any] = {}
+        if user_id is not None:
+            params["user_id"] = user_id
+        resp = await self._http.get("/api/preauths", params=params)
+        self._raise_for_error(resp)
+        return resp.json().get("preauths", [])
 
     async def get_request(self, request_id: int) -> Request:
         """Return a single request by its ID."""

--- a/src/stackcoin/client.py
+++ b/src/stackcoin/client.py
@@ -169,6 +169,18 @@ class Client:
         self._raise_for_error(resp)
         return resp.json()
 
+    async def get_preauth(self, preauth_id: int) -> dict:
+        """Get a single preauthorization with remaining budget."""
+        resp = await self._http.get(f"/api/preauth/{preauth_id}")
+        self._raise_for_error(resp)
+        return resp.json()
+
+    async def revoke_preauth(self, preauth_id: int) -> dict:
+        """Revoke an active preauthorization."""
+        resp = await self._http.post(f"/api/preauth/{preauth_id}/revoke")
+        self._raise_for_error(resp)
+        return resp.json()
+
     async def get_preauths(self, *, user_id: int | None = None) -> list[dict]:
         """List preauths for this bot, optionally filtered by user_id."""
         params: dict[str, Any] = {}

--- a/src/stackcoin/models.py
+++ b/src/stackcoin/models.py
@@ -34,6 +34,7 @@ class CreateRequestResponse(BaseModel):
     responder: Responder
     status: str = Field(..., description="Request status")
     success: bool = Field(..., description="Whether the operation succeeded")
+    transaction_id: int | None = Field(None, description="Transaction ID (set when preauth accepted)")
 
 
 class DiscordBotResponse(BaseModel):


### PR DESCRIPTION
## Summary
- Add `use_preauth` parameter to `create_request()` — when `True`, sends `use_preauth: true` in the request body so StackCoin can do an instant preauth transfer
- Add `transaction_id` field to `CreateRequestResponse` model (set when preauth accepts instantly)
- Add `create_preauth()` and `get_preauths()` methods to the `Client` class for managing preauthorizations

Part of the preauthorization feature across StackCoin, stackcoin-python, and LuckyPot.